### PR TITLE
Add core-options interface to properly compile and link to Core.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_compile_definitions(core-options INTERFACE
 )
 target_compile_options(core-options INTERFACE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: -Werror -Wall -Wno-c++2b-extensions -Wno-enum-constexpr-conversion -Wno-c++11-narrowing -Wno-deprecated-declarations -Wno-invalid-offsetof>
-    $<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra>
+    $<$<CXX_COMPILER_ID:GNU>: -Werror -Wall -Wextra -std=c++2b -Wno-invalid-offsetof>
     $<$<CXX_COMPILER_ID:MSVC>: /WX /W4>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>")
 
-# Global compile definitions.
-set(GLOBAL_COMPILE_DEFINITIONS
+add_library(core-options INTERFACE)
+target_compile_features(core-options INTERFACE cxx_std_20)
+target_compile_definitions(core-options INTERFACE
     $<$<CONFIG:DEBUG>:DEBUG=1>
     $<$<CONFIG:RELWITHDEBINFO>:DEBUG=1>
     $<$<CONFIG:RELEASE>:RELEASE=1>
@@ -33,15 +34,11 @@ set(GLOBAL_COMPILE_DEFINITIONS
     $<$<PLATFORM_ID:Linux>:PLATFORM_LINUX=1>
     $<$<PLATFORM_ID:Darwin>:PLATFORM_MACOS=1>
 )
-
-# Global compile options.
-if(MSVC)
-    set(GLOBAL_COMPILE_OPTIONS -W4 -WX -std:c++20 -Zc:preprocessor -wd5105)
-else()
-    # TODO: -Wno-deprecated-declarations is due to doctest.h sprintf() function.
-    set(GLOBAL_COMPILE_OPTIONS -Wall -Wextra -pedantic -Werror -std=c++2b -fno-exceptions -Wno-invalid-offsetof -Wno-nested-anon-types -Wno-c++11-narrowing -Wno-gnu-zero-variadic-macro-arguments -Wno-deprecated-declarations -Wno-enum-constexpr-conversion -Wno-unknown-warning-option
-    )
-endif()
+target_compile_options(core-options INTERFACE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: -Werror -Wall -Wno-c++2b-extensions -Wno-enum-constexpr-conversion -Wno-c++11-narrowing -Wno-deprecated-declarations -Wno-invalid-offsetof>
+    $<$<CXX_COMPILER_ID:GNU>: -Wall -Wextra>
+    $<$<CXX_COMPILER_ID:MSVC>: /WX /W4>
+)
 
 add_subdirectory(core)
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ target_compile_definitions(core-options INTERFACE
 target_compile_options(core-options INTERFACE
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>: -Werror -Wall -Wno-c++2b-extensions -Wno-enum-constexpr-conversion -Wno-c++11-narrowing -Wno-deprecated-declarations -Wno-invalid-offsetof>
     $<$<CXX_COMPILER_ID:GNU>: -Werror -Wall -Wextra -std=c++2b -Wno-invalid-offsetof>
-    $<$<CXX_COMPILER_ID:MSVC>: /WX /W4>
+    $<$<CXX_COMPILER_ID:MSVC>: -WX -W4 -Zc:preprocessor>
 )
 
 add_subdirectory(core)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCE_FILES
 )
 
 set(LIBS
+    core-options
 )
 
 if(WIN32)

--- a/core/defines.h
+++ b/core/defines.h
@@ -116,7 +116,7 @@ clone(const T &, memory::Allocator *)
 }
 
 template <typename T>
-inline static constexpr void
+inline static void
 destroy(T &)
 {
 	static_assert(sizeof(T) == 0, "There is no `void destroy(T &)` function overload defined for this type.");
@@ -130,7 +130,7 @@ count_of(const T (&)[N])
 }
 
 template <typename ...TArgs>
-inline static constexpr void
+inline static void
 unused(const TArgs &...)
 {
 

--- a/core/json.cpp
+++ b/core/json.cpp
@@ -2,7 +2,8 @@
 
 #include "core/platform/platform.h"
 
-#include <cerrno>
+#include <errno.h>
+#include <stdlib.h>
 
 struct JSON_Parser
 {

--- a/core/memory/heap_allocator.cpp
+++ b/core/memory/heap_allocator.cpp
@@ -3,6 +3,7 @@
 #include "core/log.h"
 #include "core/platform/platform.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #if DEBUG

--- a/core/platform/platform_linux.cpp
+++ b/core/platform/platform_linux.cpp
@@ -4,6 +4,7 @@
 #include "core/defer.h"
 #include "core/memory/memory.h"
 
+#include <stdio.h>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <limits.h>


### PR DESCRIPTION
This PR has the following:
- Add an interface called `core-options` that `Core` links to for compilation with specific options and definitions.
- Fix compilation errors  on ```Apple clang version 15.0.0 (clang-1500.3.9.4) Target: arm64-apple-darwin23.5.0o``` and `GCC 12.0`.