### PR TITLE
Fix platform_query_microseconds for macos

### DIFF
--- a/core/platform/platform_linux.cpp
+++ b/core/platform/platform_linux.cpp
@@ -761,7 +761,7 @@ platform_query_microseconds()
 	struct timespec time;
 	[[maybe_unused]] i32 result = clock_gettime(CLOCK_MONOTONIC, &time);
 	validate(result == 0, "[PLATFORM]: Failed to query clock.");
-	return time.tv_sec * 1000000.0f + time.tv_nsec * 0.001f;
+	return time.tv_sec * 1000000 + time.tv_nsec * 0.001;
 }
 
 void

--- a/core/platform/platform_macos.mm
+++ b/core/platform/platform_macos.mm
@@ -894,7 +894,7 @@ platform_query_microseconds()
 	struct timespec time;
 	[[maybe_unused]] i32 result = clock_gettime(CLOCK_MONOTONIC, &time);
 	validate(result == 0, "[PLATFORM]: Failed to query clock.");
-	return time.tv_sec * 1000000.0f + time.tv_nsec * 0.001f;
+	return time.tv_sec * 1000000 + time.tv_nsec * 0.001;
 }
 
 void


### PR DESCRIPTION
Multiplying u64 with f32 perform type conversion and before multiplication u64 is converted to f32 which causes precision loss.