### PR TITLE
Fix crash in formatter when trying to format an empty or null string.

### DIFF
--- a/core/formatter.cpp
+++ b/core/formatter.cpp
@@ -147,6 +147,9 @@ formatter()
 bool
 formatter_parse_begin(Formatter *self, const char *fmt, u64 arg_count)
 {
+	if (fmt == nullptr)
+		return false;
+
 	// Start of a new formatting.
 	if (self->current_processing_depth_index == 0)
 		_formatter_clear(self);

--- a/unittest/src/unittest_core.cpp
+++ b/unittest/src/unittest_core.cpp
@@ -220,6 +220,14 @@ TEST_CASE("[CORE]: Formatter")
 	const char *fmt_string = "{}/{}";
 	buffer = format(fmt_string, "A", "B");
 	CHECK(string_literal(buffer) == "A/B");
+
+	const char *fmt_null_c_string = nullptr;
+	buffer = format(fmt_string, fmt_null_c_string);
+	CHECK(string_literal(buffer) == "");
+
+	String fmt_null_string = {};
+	buffer = format(fmt_string, fmt_null_string);
+	CHECK(string_literal(buffer) == "");
 }
 
 TEST_CASE("[CORE]: JSON")


### PR DESCRIPTION
This PR fixes a crash that happens when trying to format a null or empty string.