### PR TITLE
Add Platform_Semaphore to Core platform.

### DIFF
--- a/core/platform/platform.h
+++ b/core/platform/platform.h
@@ -764,6 +764,26 @@ destroy(Platform_Condition_Variable *self)
 	platform_condition_variable_deinit(self);
 }
 
+struct Platform_Semaphore;
+
+CORE_API Platform_Semaphore *
+platform_semaphore_init(U32 initial_count = 0);
+
+CORE_API void
+platform_semaphore_deinit(Platform_Semaphore *self);
+
+CORE_API void
+platform_semaphore_wait(Platform_Semaphore *self);
+
+CORE_API void
+platform_semaphore_signal(Platform_Semaphore *self, U32 count = 1);
+
+inline static void
+destroy(Platform_Semaphore *self)
+{
+	platform_semaphore_deinit(self);
+}
+
 CORE_API Platform_Window
 platform_window_init(U32 width, U32 height, const char *title);
 

--- a/core/platform/platform_android.cpp
+++ b/core/platform/platform_android.cpp
@@ -2940,6 +2940,56 @@ platform_condition_variable_broadcast(Platform_Condition_Variable *self)
 	validate(::pthread_cond_broadcast(&self->handle) == 0, "[PLATFORM][ANDROID]: Failed to broadcast condition variable.");
 }
 
+struct Platform_Semaphore
+{
+	pthread_mutex_t mutex;
+	pthread_cond_t condition_variable;
+	U32 count;
+};
+
+Platform_Semaphore *
+platform_semaphore_init(U32 initial_count)
+{
+	Platform_Semaphore *self = memory::allocate_zeroed<Platform_Semaphore>();
+	validate(::pthread_mutex_init(&self->mutex, nullptr) == 0, "[PLATFORM][ANDROID]: Failed to initialize semaphore mutex.");
+	validate(::pthread_cond_init(&self->condition_variable, nullptr) == 0, "[PLATFORM][ANDROID]: Failed to initialize semaphore condition variable.");
+	self->count = initial_count;
+	return self;
+}
+
+void
+platform_semaphore_deinit(Platform_Semaphore *self)
+{
+	validate(::pthread_cond_destroy(&self->condition_variable) == 0, "[PLATFORM][ANDROID]: Failed to destroy semaphore condition variable.");
+	validate(::pthread_mutex_destroy(&self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to destroy semaphore mutex.");
+	memory::deallocate(self);
+}
+
+void
+platform_semaphore_wait(Platform_Semaphore *self)
+{
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to lock semaphore mutex.");
+	while (self->count == 0)
+		validate(::pthread_cond_wait(&self->condition_variable, &self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to wait for semaphore condition variable.");
+	--self->count;
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to unlock semaphore mutex.");
+}
+
+void
+platform_semaphore_signal(Platform_Semaphore *self, U32 count)
+{
+	if (count == 0)
+		return;
+
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to lock semaphore mutex.");
+	self->count += count;
+	if (count == 1)
+		validate(::pthread_cond_signal(&self->condition_variable) == 0, "[PLATFORM][ANDROID]: Failed to signal semaphore condition variable.");
+	else
+		validate(::pthread_cond_broadcast(&self->condition_variable) == 0, "[PLATFORM][ANDROID]: Failed to broadcast semaphore condition variable.");
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][ANDROID]: Failed to unlock semaphore mutex.");
+}
+
 Platform_Window
 platform_window_init(U32, U32, const char *)
 {

--- a/core/platform/platform_linux.cpp
+++ b/core/platform/platform_linux.cpp
@@ -950,6 +950,56 @@ platform_condition_variable_broadcast(Platform_Condition_Variable *self)
 	validate(::pthread_cond_broadcast(&self->handle) == 0, "[PLATFORM][LINUX]: Failed to broadcast condition variable.");
 }
 
+struct Platform_Semaphore
+{
+	pthread_mutex_t mutex;
+	pthread_cond_t condition_variable;
+	U32 count;
+};
+
+Platform_Semaphore *
+platform_semaphore_init(U32 initial_count)
+{
+	Platform_Semaphore *self = memory::allocate_zeroed<Platform_Semaphore>();
+	validate(::pthread_mutex_init(&self->mutex, nullptr) == 0, "[PLATFORM][LINUX]: Failed to initialize semaphore mutex.");
+	validate(::pthread_cond_init(&self->condition_variable, nullptr) == 0, "[PLATFORM][LINUX]: Failed to initialize semaphore condition variable.");
+	self->count = initial_count;
+	return self;
+}
+
+void
+platform_semaphore_deinit(Platform_Semaphore *self)
+{
+	validate(::pthread_cond_destroy(&self->condition_variable) == 0, "[PLATFORM][LINUX]: Failed to destroy semaphore condition variable.");
+	validate(::pthread_mutex_destroy(&self->mutex) == 0, "[PLATFORM][LINUX]: Failed to destroy semaphore mutex.");
+	memory::deallocate(self);
+}
+
+void
+platform_semaphore_wait(Platform_Semaphore *self)
+{
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][LINUX]: Failed to lock semaphore mutex.");
+	while (self->count == 0)
+		validate(::pthread_cond_wait(&self->condition_variable, &self->mutex) == 0, "[PLATFORM][LINUX]: Failed to wait for semaphore condition variable.");
+	--self->count;
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][LINUX]: Failed to unlock semaphore mutex.");
+}
+
+void
+platform_semaphore_signal(Platform_Semaphore *self, U32 count)
+{
+	if (count == 0)
+		return;
+
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][LINUX]: Failed to lock semaphore mutex.");
+	self->count += count;
+	if (count == 1)
+		validate(::pthread_cond_signal(&self->condition_variable) == 0, "[PLATFORM][LINUX]: Failed to signal semaphore condition variable.");
+	else
+		validate(::pthread_cond_broadcast(&self->condition_variable) == 0, "[PLATFORM][LINUX]: Failed to broadcast semaphore condition variable.");
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][LINUX]: Failed to unlock semaphore mutex.");
+}
+
 struct Platform_Window_Context
 {
 	Display *display;

--- a/core/platform/platform_macos.mm
+++ b/core/platform/platform_macos.mm
@@ -1272,6 +1272,56 @@ platform_condition_variable_broadcast(Platform_Condition_Variable *self)
 	validate(::pthread_cond_broadcast(&self->handle) == 0, "[PLATFORM][MACOS]: Failed to broadcast condition variable.");
 }
 
+struct Platform_Semaphore
+{
+	pthread_mutex_t mutex;
+	pthread_cond_t condition_variable;
+	U32 count;
+};
+
+Platform_Semaphore *
+platform_semaphore_init(U32 initial_count)
+{
+	Platform_Semaphore *self = memory::allocate_zeroed<Platform_Semaphore>();
+	validate(::pthread_mutex_init(&self->mutex, nullptr) == 0, "[PLATFORM][MACOS]: Failed to initialize semaphore mutex.");
+	validate(::pthread_cond_init(&self->condition_variable, nullptr) == 0, "[PLATFORM][MACOS]: Failed to initialize semaphore condition variable.");
+	self->count = initial_count;
+	return self;
+}
+
+void
+platform_semaphore_deinit(Platform_Semaphore *self)
+{
+	validate(::pthread_cond_destroy(&self->condition_variable) == 0, "[PLATFORM][MACOS]: Failed to destroy semaphore condition variable.");
+	validate(::pthread_mutex_destroy(&self->mutex) == 0, "[PLATFORM][MACOS]: Failed to destroy semaphore mutex.");
+	memory::deallocate(self);
+}
+
+void
+platform_semaphore_wait(Platform_Semaphore *self)
+{
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][MACOS]: Failed to lock semaphore mutex.");
+	while (self->count == 0)
+		validate(::pthread_cond_wait(&self->condition_variable, &self->mutex) == 0, "[PLATFORM][MACOS]: Failed to wait for semaphore condition variable.");
+	--self->count;
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][MACOS]: Failed to unlock semaphore mutex.");
+}
+
+void
+platform_semaphore_signal(Platform_Semaphore *self, U32 count)
+{
+	if (count == 0)
+		return;
+
+	validate(::pthread_mutex_lock(&self->mutex) == 0, "[PLATFORM][MACOS]: Failed to lock semaphore mutex.");
+	self->count += count;
+	if (count == 1)
+		validate(::pthread_cond_signal(&self->condition_variable) == 0, "[PLATFORM][MACOS]: Failed to signal semaphore condition variable.");
+	else
+		validate(::pthread_cond_broadcast(&self->condition_variable) == 0, "[PLATFORM][MACOS]: Failed to broadcast semaphore condition variable.");
+	validate(::pthread_mutex_unlock(&self->mutex) == 0, "[PLATFORM][MACOS]: Failed to unlock semaphore mutex.");
+}
+
 // TODO: Return early with error message if failed to create objects.
 Platform_Window
 platform_window_init(U32 width, U32 height, const char *title)

--- a/core/platform/platform_win32.cpp
+++ b/core/platform/platform_win32.cpp
@@ -1060,6 +1060,43 @@ platform_condition_variable_broadcast(Platform_Condition_Variable *self)
 	::WakeAllConditionVariable(&self->handle);
 }
 
+struct Platform_Semaphore
+{
+	HANDLE handle;
+};
+
+Platform_Semaphore *
+platform_semaphore_init(U32 initial_count)
+{
+	constexpr LONG max_count = 0x7fffffff;
+	Platform_Semaphore *self = memory::allocate_zeroed<Platform_Semaphore>();
+	self->handle = ::CreateSemaphoreW(nullptr, (LONG)initial_count, max_count, nullptr);
+	validate(self->handle != nullptr, "[PLATFORM][WINDOWS]: Failed to initialize semaphore.");
+	return self;
+}
+
+void
+platform_semaphore_deinit(Platform_Semaphore *self)
+{
+	validate(::CloseHandle(self->handle), "[PLATFORM][WINDOWS]: Failed to close semaphore handle.");
+	memory::deallocate(self);
+}
+
+void
+platform_semaphore_wait(Platform_Semaphore *self)
+{
+	DWORD wait_result = ::WaitForSingleObject(self->handle, INFINITE);
+	validate(wait_result == WAIT_OBJECT_0, "[PLATFORM][WINDOWS]: Failed to wait for semaphore.");
+}
+
+void
+platform_semaphore_signal(Platform_Semaphore *self, U32 count)
+{
+	if (count == 0)
+		return;
+	validate(::ReleaseSemaphore(self->handle, (LONG)count, nullptr), "[PLATFORM][WINDOWS]: Failed to signal semaphore.");
+}
+
 inline static void
 _platform_win32_window_keep_screen_on_set(Platform_Window_Context *ctx, bool enabled)
 {

--- a/unittest/src/unittest_core.cpp
+++ b/unittest/src/unittest_core.cpp
@@ -81,6 +81,78 @@ TESTER_TEST("[CORE]: Atomic Threads")
 	TESTER_CHECK(atomic_load(counter) == (U64)THREAD_COUNT * ITERATION_COUNT);
 }
 
+struct Platform_Semaphore_Test_Context
+{
+	Platform_Semaphore *ready_semaphore;
+	Platform_Semaphore *start_semaphore;
+	Platform_Semaphore *done_semaphore;
+	Platform_Mutex *mutex;
+	U32 finished_count;
+};
+
+inline static void
+_platform_semaphore_test_thread(void *data)
+{
+	Platform_Semaphore_Test_Context *context = (Platform_Semaphore_Test_Context *)data;
+	platform_semaphore_signal(context->ready_semaphore);
+	platform_semaphore_wait(context->start_semaphore);
+
+	platform_mutex_lock(context->mutex);
+	++context->finished_count;
+	platform_mutex_unlock(context->mutex);
+
+	platform_semaphore_signal(context->done_semaphore);
+}
+
+TESTER_TEST("[CORE]: Platform Semaphore")
+{
+	constexpr U32 THREAD_COUNT = 4;
+
+	Platform_Semaphore *ready_semaphore = platform_semaphore_init();
+	Platform_Semaphore *start_semaphore = platform_semaphore_init();
+	Platform_Semaphore *done_semaphore = platform_semaphore_init();
+	Platform_Mutex *mutex = platform_mutex_init();
+	Platform_Semaphore_Test_Context context = {
+		.ready_semaphore = ready_semaphore,
+		.start_semaphore = start_semaphore,
+		.done_semaphore = done_semaphore,
+		.mutex = mutex
+	};
+	Platform_Thread *threads[THREAD_COUNT];
+
+	for (U32 i = 0; i < THREAD_COUNT; ++i)
+	{
+		threads[i] = platform_thread_init(Platform_Thread_Desc {
+			.function = _platform_semaphore_test_thread,
+			.data = &context,
+			.name = "SemaphoreTest"
+		});
+	}
+
+	for (U32 i = 0; i < THREAD_COUNT; ++i)
+		platform_semaphore_wait(ready_semaphore);
+
+	platform_mutex_lock(mutex);
+	TESTER_CHECK(context.finished_count == 0);
+	platform_mutex_unlock(mutex);
+
+	platform_semaphore_signal(start_semaphore, THREAD_COUNT);
+	for (U32 i = 0; i < THREAD_COUNT; ++i)
+		platform_semaphore_wait(done_semaphore);
+
+	for (U32 i = 0; i < THREAD_COUNT; ++i)
+		platform_thread_deinit(threads[i]);
+
+	platform_mutex_lock(mutex);
+	TESTER_CHECK(context.finished_count == THREAD_COUNT);
+	platform_mutex_unlock(mutex);
+
+	platform_mutex_deinit(mutex);
+	platform_semaphore_deinit(done_semaphore);
+	platform_semaphore_deinit(start_semaphore);
+	platform_semaphore_deinit(ready_semaphore);
+}
+
 TESTER_TEST("[CORE]: Scheduler")
 {
 	Scheduler *scheduler = scheduler_init(Scheduler_Desc {


### PR DESCRIPTION
## Summary

This PR adds a cross-platform `Platform_Semaphore` primitive to Core.

Semaphores give us a simple way for one thread to sleep until another thread signals that work, a resource, or a slot is available. This fills the gap between atomics, which only protect values, and condition variables, which require callers to manage a mutex and predicate directly.

## What Changed

- Added `Platform_Semaphore` to the platform layer.
- Added `platform_semaphore_init`, `platform_semaphore_deinit`, `platform_semaphore_wait`, and `platform_semaphore_signal`.
- Implemented semaphore support on Windows, Linux, macOS, and Android.
- Added unit coverage for blocking worker threads, releasing them with a counted signal, and verifying all workers complete correctly.