### PR TITLE
Fix string_replace() implicit conversion bug and platform_path_get_file_name().

### DIFF
--- a/core/containers/string.h
+++ b/core/containers/string.h
@@ -625,13 +625,10 @@ string_replace(String &self, char to_replace, char replacement)
 inline static void
 string_replace(String &self, const String &to_replace, const String &replacement)
 {
-	auto splits = string_split(self, to_replace, memory::temp_allocator());
+	auto splits = string_split(self, to_replace, false, memory::temp_allocator());
 	DEFER(destroy(splits));
 
 	String copy = string_init(self.allocator);
-	if (string_starts_with(self, to_replace))
-		string_append(copy, replacement);
-
 	for (U64 i = 0; i < splits.count; ++i)
 	{
 		string_append(copy, splits[i]);

--- a/core/platform/platform_android.cpp
+++ b/core/platform/platform_android.cpp
@@ -2469,13 +2469,16 @@ platform_path_get_current_module_path(memory::Allocator *allocator)
 String
 platform_path_get_file_name(const String &path, memory::Allocator *allocator)
 {
+	if (path.count == 0)
+		return string_init(allocator);
+
 	if (_platform_android_is_content_uri(path.data))
 		return _platform_android_content_display_name(path.data, allocator);
 
-	String path_temp = string_copy(path, memory::temp_allocator());
-	string_replace(path_temp, "\\", "/");
-	Array<String> splits = string_split(path_temp, "/", true, memory::temp_allocator());
-	return string_copy(array_back(splits), allocator);
+	U64 slash = string_find_last_of(path, '/');
+	U64 backslash = string_find_last_of(path, '\\');
+	U64 separator = backslash != U64(-1) && (slash == U64(-1) || backslash > slash) ? backslash : slash;
+	return string_from(path.data + (separator == U64(-1) ? 0 : separator + 1), path.data + path.count, allocator);
 }
 
 String

--- a/core/platform/platform_linux.cpp
+++ b/core/platform/platform_linux.cpp
@@ -402,10 +402,13 @@ platform_path_get_current_module_path(memory::Allocator *allocator)
 String
 platform_path_get_file_name(const String &path, memory::Allocator *allocator)
 {
-	String path_temp = string_copy(path, memory::temp_allocator());
-	string_replace(path_temp, "\\", "/");
-	Array<String> splits = string_split(path_temp, "/", true, memory::temp_allocator());
-	return string_copy(array_back(splits), allocator);
+	if (path.count == 0)
+		return string_init(allocator);
+
+	U64 slash = string_find_last_of(path, '/');
+	U64 backslash = string_find_last_of(path, '\\');
+	U64 separator = backslash != U64(-1) && (slash == U64(-1) || backslash > slash) ? backslash : slash;
+	return string_from(path.data + (separator == U64(-1) ? 0 : separator + 1), path.data + path.count, allocator);
 }
 
 String

--- a/core/platform/platform_macos.mm
+++ b/core/platform/platform_macos.mm
@@ -726,10 +726,13 @@ platform_path_get_current_module_path(memory::Allocator *allocator)
 String
 platform_path_get_file_name(const String &path, memory::Allocator *allocator)
 {
-	String path_temp = string_copy(path, memory::temp_allocator());
-	string_replace(path_temp, "\\", "/");
-	Array<String> splits = string_split(path_temp, "/", true, memory::temp_allocator());
-	return string_copy(array_back(splits), allocator);
+	if (path.count == 0)
+		return string_init(allocator);
+
+	U64 slash = string_find_last_of(path, '/');
+	U64 backslash = string_find_last_of(path, '\\');
+	U64 separator = backslash != U64(-1) && (slash == U64(-1) || backslash > slash) ? backslash : slash;
+	return string_from(path.data + (separator == U64(-1) ? 0 : separator + 1), path.data + path.count, allocator);
 }
 
 String

--- a/core/platform/platform_win32.cpp
+++ b/core/platform/platform_win32.cpp
@@ -271,12 +271,13 @@ platform_path_is_directory(const String &path)
 String
 platform_path_get_absolute(const String &path, memory::Allocator *allocator)
 {
-	DWORD full_path_length = ::GetFullPathName(path.data, 0, nullptr, nullptr);
+	DWORD required_length = ::GetFullPathName(path.data, 0, nullptr, nullptr);
+	validate(required_length > 0, "[PLATFORM][WIN32]: Failed to get absolute path length.");
 
-	String full_path = string_init(allocator);
+	String full_path = string_with_capacity(required_length + 1, allocator);
+	DWORD full_path_length = ::GetFullPathName(path.data, (DWORD)full_path.capacity, full_path.data, nullptr);
+	validate(full_path_length > 0 && full_path_length < full_path.capacity, "[PLATFORM][WIN32]: Failed to get absolute path.");
 	string_resize(full_path, full_path_length);
-
-	validate(::GetFullPathName(path.data, full_path_length, full_path.data, nullptr));
 
 	string_replace(full_path, '\\', '/');
 
@@ -304,11 +305,13 @@ platform_path_get_directory(const String &path, memory::Allocator *allocator)
 String
 platform_path_get_current_working_directory(memory::Allocator *allocator)
 {
-	DWORD path_directory_length = ::GetCurrentDirectory(0, nullptr);
+	DWORD required_length = ::GetCurrentDirectory(0, nullptr);
+	validate(required_length > 0, "[PLATFORM][WIN32]: Failed to get current working directory length.");
 
-	String path_directory = string_init(allocator);
+	String path_directory = string_with_capacity(required_length + 1, allocator);
+	DWORD path_directory_length = ::GetCurrentDirectory((DWORD)path_directory.capacity, path_directory.data);
+	validate(path_directory_length > 0 && path_directory_length < path_directory.capacity, "[PLATFORM][WIN32]: Failed to get current working directory.");
 	string_resize(path_directory, path_directory_length);
-	validate(::GetCurrentDirectory(path_directory_length, path_directory.data));
 	string_replace(path_directory, '\\', '/');
 	return path_directory;
 }
@@ -416,10 +419,13 @@ platform_path_get_current_module_path(memory::Allocator *allocator)
 String
 platform_path_get_file_name(const String &path, memory::Allocator *allocator)
 {
-	String path_temp = string_copy(path, memory::temp_allocator());
-	string_replace(path_temp, "\\", "/");
-	Array<String> splits = string_split(path_temp, "/", true, memory::temp_allocator());
-	return string_copy(array_back(splits), allocator);
+	if (path.count == 0)
+		return string_init(allocator);
+
+	U64 slash = string_find_last_of(path, '/');
+	U64 backslash = string_find_last_of(path, '\\');
+	U64 separator = backslash != U64(-1) && (slash == U64(-1) || backslash > slash) ? backslash : slash;
+	return string_from(path.data + (separator == U64(-1) ? 0 : separator + 1), path.data + path.count, allocator);
 }
 
 String

--- a/unittest/src/unittest_containers.cpp
+++ b/unittest/src/unittest_containers.cpp
@@ -514,6 +514,14 @@ TESTER_TEST("[CONTAINERS]: String")
 		TESTER_CHECK(s2 == "Hello, xxxWorld!");
 		string_replace_first_occurance(s2, "xxx", "");
 		TESTER_CHECK(s2 == "Hello, World!");
+
+		auto s3 = string_from("xxxHelloxxxxxxWorldxxx", memory::temp_allocator());
+		string_replace(s3, "xxx", "-");
+		TESTER_CHECK(s3 == "-Hello--World-");
+
+		auto s4 = string_from("aaaa", memory::temp_allocator());
+		string_replace(s4, "aa", "b");
+		TESTER_CHECK(s4 == "bb");
 	}
 
 	// ("starts with")

--- a/unittest/src/unittest_platform.cpp
+++ b/unittest/src/unittest_platform.cpp
@@ -257,10 +257,29 @@ TESTER_TEST("[PLATFORM] path utilities")
 	String executable_path = platform_path_get_executable_path(memory::temp_allocator());
 	TESTER_CHECK(executable_path.count > 0);
 	TESTER_CHECK(platform_path_is_file(executable_path));
+	TESTER_CHECK(executable_path.count == string_literal(executable_path.data).count);
+	TESTER_CHECK(executable_path.data[executable_path.count] == '\0');
 
 	String module_path = platform_path_get_current_module_path(memory::temp_allocator());
 	TESTER_CHECK(module_path.count > 0);
 	TESTER_CHECK(platform_path_is_file(module_path));
+	TESTER_CHECK(module_path.count == string_literal(module_path.data).count);
+	TESTER_CHECK(module_path.data[module_path.count] == '\0');
+
+	String working_directory = platform_path_get_current_working_directory(memory::temp_allocator());
+	TESTER_CHECK(working_directory.count > 0);
+	TESTER_CHECK(working_directory.count == string_literal(working_directory.data).count);
+	TESTER_CHECK(working_directory.data[working_directory.count] == '\0');
+
+	String absolute_path = platform_path_get_absolute(".", memory::temp_allocator());
+	TESTER_CHECK(absolute_path.count > 0);
+	TESTER_CHECK(absolute_path.count == string_literal(absolute_path.data).count);
+	TESTER_CHECK(absolute_path.data[absolute_path.count] == '\0');
+
+	TESTER_CHECK(platform_path_get_file_name("folder\\sub/file.txt", memory::temp_allocator()) == "file.txt");
+	TESTER_CHECK(platform_path_get_file_name("file.txt", memory::temp_allocator()) == "file.txt");
+	TESTER_CHECK(platform_path_get_file_name("folder/", memory::temp_allocator()).count == 0);
+	TESTER_CHECK(platform_path_get_file_name(String{}, memory::temp_allocator()).count == 0);
 
 	String missing_env = platform_environment_variable_get("__CORE_UNITTEST_MISSING_ENVIRONMENT_VARIABLE__", memory::temp_allocator());
 	TESTER_CHECK(missing_env.count == 0);


### PR DESCRIPTION
## Summary

Fixes several Core string and path-handling issues uncovered while upgrading MPL to Core commit `49a4f2795b09feed9747a9c9603ba7b6076156d8`.

## Changes

- Fix `string_replace(String&, String, String)` passing the temporary allocator into `string_split`'s `skip_empty` argument.
- Preserve leading, trailing, and adjacent replacement matches.
- Replace filename normalization and splitting with a direct scan for the final `/` or `\`.
- Apply filename extraction consistently across Win32, Linux, macOS, and Android.
- Handle empty paths and paths ending in a separator.
- Fix Win32 absolute-path and current-working-directory queries so the null terminator is excluded from `String::count`.
- Add regression coverage for replacement multiplicity, mixed separators, empty paths, trailing separators, null termination, and Win32 path counts.

## Root causes

The string replacement implementation called:

```cpp
string_split(self, to_replace, memory::temp_allocator());